### PR TITLE
Rename mod to include Don't Fade and Don't Enter in the name (+minor optimization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # No Block Glow
-A Geode mod for Geometry Dash that automatically enables No Glow on placed objects in the level editor.
+A Geode mod for Geometry Dash that automatically enables No Glow, Don't Fade, and Don't Enter on placed objects in the level editor.
 
 ![image](https://github.com/user-attachments/assets/46dd90e8-0e73-4fc6-a638-e6f2b11fc050)
-
-The mod also includes support for enabling Don't Fade and Don't Enter automatically. You can find these options in the mod settings.

--- a/about.md
+++ b/about.md
@@ -1,4 +1,2 @@
 # No Block Glow
-A Geode mod for Geometry Dash that automatically enables <cj>No Glow</c> on placed objects in the level editor.
-
-Also includes settings to automatically enable <cj>Don't Fade</c> and <cj>Don't Enter</c> on placed objects in the level editor.
+A Geode mod for Geometry Dash that automatically enables <cj>No Glow</c>, <cj>Don't Fade</c>, and <cj>Don't Enter</c> on placed objects in the level editor.

--- a/changelog.md
+++ b/changelog.md
@@ -3,3 +3,6 @@
 
 # 1.0.1
 - Updated to support Geometry Dash v2.207
+
+# 1.0.2
+- Rename mod to include Don't Fade and Don't Enter in the name

--- a/mod.json
+++ b/mod.json
@@ -7,8 +7,8 @@
 		"ios": "2.2074"
 	},
 	"id": "bry400.no_block_glow",
-	"name": "No Block Glow",
-	"version": "v1.0.1",
+	"name": "NoGlow/Don't Fade/Don't Enter",
+	"version": "v1.0.2",
 	"developer": "bry400",
 	"description": "Removes object glow when placing objects into the editor.",
 	"repository": "https://github.com/kazido/No-Block-Glow",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,14 +3,35 @@
 using namespace geode::prelude;
 
 #include <Geode/modify/LevelEditorLayer.hpp>
-class $modify(LevelEditorLayer) {
-	GameObject* createObject(int p0, cocos2d::CCPoint p1, bool p2) {
-		GameObject* object = LevelEditorLayer::createObject(p0, p1, p2);
 
-		object->m_hasNoGlow = Mod::get()->getSettingValue<bool>("no-glow");
-		object->m_isDontFade = Mod::get()->getSettingValue<bool>("dont-fade");
-		object->m_isDontEnter = Mod::get()->getSettingValue<bool>("dont-enter");
+bool dontFade = true;
+bool dontEnter = true;
+bool noGlow = false;
+$execute{
+	dontFade = Mod::get()->getSettingValue<bool>("dont-fade");
+	listenForSettingChanges("dont-fade", [](bool value) {
+		dontFade = value;
+	});
 
-        return object;
-    }
+	dontEnter = Mod::get()->getSettingValue<bool>("dont-enter");
+	listenForSettingChanges("dont-enter", [](bool value) {
+		dontEnter = value;
+	});
+
+	noGlow = Mod::get()->getSettingValue<bool>("no-glow");
+	listenForSettingChanges("no-glow", [](bool value) {
+		noGlow = value;
+	});
+}
+
+class $modify(LevelEditorLayerHook, LevelEditorLayer) {
+	GameObject* createObject(int key, CCPoint position, bool noUndo) {
+		GameObject* object = LevelEditorLayer::createObject(key, position, noUndo);
+		
+		object->m_isDontFade = dontFade;
+		object->m_isDontEnter = dontEnter;
+		object->m_hasNoGlow = noGlow;
+
+		return object;
+	}
 };


### PR DESCRIPTION
I'm thinking that this mod would be better if its name included "Don't Fade" and "Don't Enter", since a lot of people will probably search those up looking for a mod of this functionality. "No Glow" is honestly a bit more niche and uncommonly paid attention to than "Don't Fade" and "Don't Enter". This does nothing except change the name of the mod.  
  
I mentioned this to some developers in the Geode discord and some of them agree it would be better of renamed.